### PR TITLE
Separate configuration for 16-bit and for 32/64-bit targets

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -53,11 +53,16 @@
 #undef USE_DYNIP_CLI   /* Support DynDNS.org name/IP client */
 #undef USE_SCTP        /* Stream Control Transfer Protocol; experimental */
 
+#if (DOSX == 0)
+/*
+ * configure 16-bit targets
+ */
+
 /*
  * Building small-model applications doesn't leave
  * much room for the fancy stuff :-(
  */
-#if !defined(OPT_DEFINED) && defined(__SMALL__) && !defined(__SMALL32__)
+#if !defined(OPT_DEFINED) && defined(__SMALL__)
   #define USE_UDP_ONLY     /* test udp-only (cookie,ping) */
   #define OPT_DEFINED
 #endif
@@ -76,6 +81,11 @@
   #define USE_DEBUG
   #define OPT_DEFINED
 #endif
+
+#else 
+/*
+ * configure 32/64-bit targets
+ */
 
 /*
  * Otherwise, for all targets define these options:
@@ -100,8 +110,8 @@
 /*
  * Add some more options for djgpp, HighC, 32-bit Watcom/DMC and Win32/64
  */
-#if defined(__DJGPP__) || defined(__HIGHC__) || defined(WATCOM386) || \
-    defined(DMC386) || defined(_WIN32) || defined(_WIN64)
+#if defined(__DJGPP__) || defined(__HIGHC__) || defined(__WATCOMC__) || \
+    defined(__DMC__) || defined(_WIN32) || defined(_WIN64)
   #define USE_ECHO_DISC
   #define USE_RARP
   #define USE_IPV6
@@ -123,14 +133,15 @@
 /* #define USE_FORTIFY */
 #endif
 
-#if (DOSX && DOSX != WINWATT)
+#if (DOSX != WINWATT)
   #define USE_FAST_PKT
 #endif
 
-#if (DOSX) && defined(HAVE_UINT64)
+#if defined(HAVE_UINT64)
   #define USE_PROFILER
 #endif
 
+#endif
 
 /*
  * SCTP needs gzip compress/uncompress.

--- a/src/cpumodel.h
+++ b/src/cpumodel.h
@@ -299,9 +299,8 @@ extern CONST char  DATA_DECL x86_vendor_id[13];
 #endif
 
 
-#if 0 && (defined(__BORLANDC__) || defined(__DMC__)) && \
-         (defined(__SMALL__) || defined(__LARGE__)) && \
-         defined(__SMALL32__)
+#if 0 && (DOSX == 0) && (defined(__BORLANDC__) || defined(__DMC__)) && \
+         (defined(__SMALL__) || defined(__LARGE__))
   /*
    * Save FPU state.
    */

--- a/src/misc.h
+++ b/src/misc.h
@@ -781,7 +781,7 @@ extern const char *short_strerror (int errnum);
   #define PUSHF_CLI()     __asm__ __volatile__ ("pushfl; cli" ::: "memory")
   #define POPF()          __asm__ __volatile__ ("popfl"       ::: "memory")
 
-#elif (defined(__SMALL__) || defined(__LARGE__)) && !defined(__SMALL32__)
+#elif (DOSX == 0) && (defined(__SMALL__) || defined(__LARGE__))
   #if defined(__BORLANDC__) /* prevent spawning tasm.exe */
     #define PUSHF_CLI()   __emit__ (0x9C,0xFA)
     #define POPF()        __emit__ (0x9D)

--- a/src/sock_dbu.c
+++ b/src/sock_dbu.c
@@ -19,10 +19,12 @@ void W32_CALL sock_debugdump (const sock_type *s)
   if (s->raw.ip_type == IP4_TYPE)
      return;
 
-#if defined(__SMALL__) && !defined(__SMALL32__)
-  (*_printf) ("next       %04X\n",      s->tcp.next);
-#elif defined(__LARGE__)
-  (*_printf) ("next       %04X:%04X\n", FP_SEG(s->tcp.next), FP_OFF(s->tcp.next));
+#if (DOSX == 0)
+  #if defined(__SMALL__)
+    (*_printf) ("next       %04X\n",      s->tcp.next);
+  #elif defined(__LARGE__)
+    (*_printf) ("next       %04X:%04X\n", FP_SEG(s->tcp.next), FP_OFF(s->tcp.next));
+  #endif
 #else
   (*_printf) ("next       %" ADDR_FMT "\n", ADDR_CAST(s->tcp.next));
 #endif

--- a/src/sock_ini.c
+++ b/src/sock_ini.c
@@ -1165,7 +1165,7 @@ void W32_CALL sock_sig_exit (const char *msg, int sig)
 #elif defined(__DMC__) && 0
   #if defined(WIN32)
     #pragma comment (lib, "wattcpd_imp.lib")
-  #elif defined(__SMALL32__)
+  #elif defined(DMC386)
     #pragma comment (lib, "wattcpDF.lib")
   #elif defined(__SMALL__)
     #pragma comment (lib, "wattcpDS.lib")

--- a/src/target.h
+++ b/src/target.h
@@ -69,38 +69,23 @@
   #error Unsupported memory model (medium/huge)
 #endif
 
-/* 32-bit Digital Mars Compiler defines __SMALL__. So take care when testing
- * for real __SMALL__.
- */
-#if defined(__DMC__) && (__INTSIZE==4) && defined(__SMALL__)
-  #define __SMALL32__
-  #define DMC386
-#endif
-
-#if (defined(__SMALL__) || defined(__LARGE__)) && !defined(__SMALL32__)
-  #undef  DOSX
-  #define DOSX 0
-#endif
-
 /*
  * djgpp 2.x with GNU C 2.7 or later.
  */
 #if defined(__DJGPP__) && defined(__GNUC__)
-  #undef  DOSX
-  #define DOSX      DJGPP
+  #ifndef  DOSX
+    #define DOSX      DJGPP
+  #endif
 #endif
 
 /*
- * Watcom 11.x or OpenWatcom 1.x.
+ * Watcom 11.x or OpenWatcom.
  */
 #if defined(__WATCOMC__) && defined(__386__)
-  #ifndef DOSX              /* If not set in watcom_*.mak file */
-    #undef  DOSX
-    #define DOSX    DOS4GW  /* may be DOS4GW, X32VM, PHARLAP or WINWATT */
-  #endif
+  #define WATCOM386
 
-  #if !defined(__SMALL__) && !defined(__LARGE__)
-  #define WATCOM386 1
+  #ifndef DOSX              /* If not set in watcom_*.mak file */
+    #define DOSX    DOS4GW  /* may be DOS4GW, X32VM, PHARLAP or WINWATT */
   #endif
 #endif
 
@@ -108,8 +93,9 @@
  * Digital Mars Compiler 8.30+
  */
 #if defined(__DMC__) && (__INTSIZE==4)
+  #define DMC386
+
   #ifndef DOSX              /* If not set in dmars_*.mak file */
-    #undef  DOSX
     #define DOSX   PHARLAP  /* may be X32VM, DOS4GW or PHARLAP */
   #endif
 #endif
@@ -130,8 +116,10 @@
    */
   #pragma warn (disable: 2116)
 
-  #undef  DOSX
-  #define DOSX      WINWATT
+  #ifndef  DOSX
+    #define DOSX      WINWATT
+  #endif
+
   #undef _MSC_VER
 #endif
 
@@ -140,9 +128,11 @@
  * but works with Win32 as target.
  */
 #if defined(_MSC_VER) && (_M_IX86 >= 300)
-  #undef  DOSX
-  #define DOSX      WINWATT  /* VC 2.0 can use PHARLAP too */
   #define MSC386
+
+  #ifndef  DOSX
+    #define DOSX      WINWATT  /* VC 2.0 can use PHARLAP too */
+  #endif
 #endif
 
 /*
@@ -156,8 +146,9 @@
   #define __i386__
   #endif
 
-  #undef  DOSX
-  #define DOSX      PHARLAP   /* Is DOS4GW possible? */
+  #ifndef  DOSX
+    #define DOSX      PHARLAP   /* Is DOS4GW possible? */
+  #endif
 #endif
 
 /*
@@ -165,38 +156,46 @@
  */
 #if defined(__BORLANDC__) && defined(__FLAT__) && defined(__DPMI32__)
   #define BORLAND386
-  #undef  DOSX
-  #define DOSX      POWERPAK  /* may also be DOS4GW (for WDOSX targets) */
-                              /* or PHARLAP (not yet) */
-#endif
 
-#if defined(__BORLANDC__) && defined(WIN32)
-  #undef  DOSX
-  #define DOSX      WINWATT
+  #ifndef  DOSX
+    #define DOSX      POWERPAK  /* may also be DOS4GW (for WDOSX targets) */
+                              /* or PHARLAP (not yet) */
+  #endif
 #endif
 
 /*
  * LadSoft (cc386 is rather buggy, so it's not really supported)
  */
 #if defined(__CCDL__) && defined(__386__)
-  #undef  DOSX
-  #define DOSX      DOS4GW
+  #ifndef  DOSX
+    #define DOSX      DOS4GW
+  #endif
 #endif
 
 /*
  * Build for Windows (dll and static lib).
  */
 #if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(__CYGWIN__)
-  #undef  DOSX
-  #define DOSX      WINWATT
+  #ifndef  DOSX
+    #define DOSX      WINWATT
+  #endif
 #endif
 
-#if defined(__CYGWIN__) && defined(_REENT_ONLY) && defined(WATT32_BUILD)
-  #error "CygWin with _REENT_ONLY is not supported."
+/*
+ * Build for 16-bit DOS.
+ */
+#if defined(__SMALL__) || defined(__LARGE__)
+  #ifndef  DOSX
+    #define DOSX 0
+  #endif
 #endif
 
 #if !defined(DOSX)
   #error DOSX target not defined
+#endif
+
+#if defined(__CYGWIN__) && defined(_REENT_ONLY) && defined(WATT32_BUILD)
+  #error "CygWin with _REENT_ONLY is not supported."
 #endif
 
 #if (defined(MSDOS) || defined(_MSDOS)) && !defined(__MSDOS__)

--- a/src/zconf.h
+++ b/src/zconf.h
@@ -108,7 +108,7 @@
 #    ifndef SYS16BIT
 #      define SYS16BIT
 #    endif
-#    if defined(__DMC__) && defined(__SMALL32__)
+#    if defined(DMC386)
 #      undef SYS16BIT
 #    endif
 #  endif


### PR DESCRIPTION
Most of exceptions/limitations exists for 16-bit targets that it is useful separate 16-bit configuration from 32/64-bit one

16-bit configuration is defined by macro condition (DOSX == 0)
32/64-bit configuration is defined by macro condition (DOSX != 0)

Remove `__SMALL32__ `macro as useless and confusing
`__SMALL__ `and `__LARGE__ `macros must be used with (DOSX == 0)