### PR TITLE
macros should cast as const to prevent warnings if input is const

### DIFF
--- a/inc/netinet/in.h
+++ b/inc/netinet/in.h
@@ -398,50 +398,50 @@ struct ip_mreq {
  */
 #ifndef IN6_IS_ADDR_UNSPECIFIED
 #define IN6_IS_ADDR_UNSPECIFIED(a)      \
-           (((u_int32_t*)(a))[0] == 0   \
-         && ((u_int32_t*)(a))[1] == 0   \
-         && ((u_int32_t*)(a))[2] == 0   \
-         && ((u_int32_t*)(a))[3] == 0)
+           (((const u_int32_t*)(a))[0] == 0   \
+         && ((const u_int32_t*)(a))[1] == 0   \
+         && ((const u_int32_t*)(a))[2] == 0   \
+         && ((const u_int32_t*)(a))[3] == 0)
 #endif
 
 #ifndef IN6_IS_ADDR_LOOPBACK
 #define IN6_IS_ADDR_LOOPBACK(a)         \
-           (((u_int32_t*)(a))[0] == 0   \
-         && ((u_int32_t*)(a))[1] == 0   \
-         && ((u_int32_t*)(a))[2] == 0   \
-         && ((u_int32_t*)(a))[3] == htonl (1))
+           (((const u_int32_t*)(a))[0] == 0   \
+         && ((const u_int32_t*)(a))[1] == 0   \
+         && ((const u_int32_t*)(a))[2] == 0   \
+         && ((const u_int32_t*)(a))[3] == htonl (1))
 #endif
 
 #ifndef IN6_IS_ADDR_MULTICAST
-#define IN6_IS_ADDR_MULTICAST(a) (((u_int8_t*) (a))[0] == 0xff)
+#define IN6_IS_ADDR_MULTICAST(a) (((const u_int8_t*) (a))[0] == 0xff)
 #endif
 
 #define IN6_IS_ADDR_LINKLOCAL(a) \
-        ((((u_int32_t*)(a))[0] & htonl(0xffc00000)) == htonl(0xfe800000))
+        ((((const u_int32_t*)(a))[0] & htonl(0xffc00000)) == htonl(0xfe800000))
 
 #ifndef IN6_IS_ADDR_SITELOCAL
 #define IN6_IS_ADDR_SITELOCAL(a) \
-        ((((u_int32_t*)(a))[0] & htonl(0xffc00000)) == htonl(0xfec00000))
+        ((((const u_int32_t*)(a))[0] & htonl(0xffc00000)) == htonl(0xfec00000))
 #endif
 
 #ifndef IN6_IS_ADDR_V4MAPPED
 #define IN6_IS_ADDR_V4MAPPED(a)         \
-           ((((u_int32_t*)(a))[0] == 0) \
-         && (((u_int32_t*)(a))[1] == 0) \
-         && (((u_int32_t*)(a))[2] == htonl(0xffff)))
+           ((((const u_int32_t*)(a))[0] == 0) \
+         && (((const u_int32_t*)(a))[1] == 0) \
+         && (((const u_int32_t*)(a))[2] == htonl(0xffff)))
 #endif
 
 #ifndef IN6_IS_ADDR_V4COMPAT
 #define IN6_IS_ADDR_V4COMPAT(a)         \
-           ((((u_int32_t*)(a))[0] == 0) \
-         && (((u_int32_t*)(a))[1] == 0) \
-         && (((u_int32_t*)(a))[2] == 0) \
-         && (ntohl(((u_int32_t*)(a))[3]) > 1))
+           ((((const u_int32_t*)(a))[0] == 0) \
+         && (((const u_int32_t*)(a))[1] == 0) \
+         && (((const u_int32_t*)(a))[2] == 0) \
+         && (ntohl(((const u_int32_t*)(a))[3]) > 1))
 #endif
 
 #ifndef IN6_ARE_ADDR_EQUAL
 #define IN6_ARE_ADDR_EQUAL(a, b) \
-        (memcmp ((void*)(a), (void*)(b), sizeof(struct in6_addr)) == 0)
+        (memcmp ((const void*)(a), (const void*)(b), sizeof(struct in6_addr)) == 0)
 #endif
 
 #ifndef IN6_ADDR_EQUAL
@@ -450,27 +450,27 @@ struct ip_mreq {
 
 #ifndef IN6_IS_ADDR_MC_NODELOCAL
 #define IN6_IS_ADDR_MC_NODELOCAL(a) \
-        (IN6_IS_ADDR_MULTICAST(a) && ((((u_int8_t*)(a))[1] & 0xf) == 0x1))
+        (IN6_IS_ADDR_MULTICAST(a) && ((((const u_int8_t*)(a))[1] & 0xf) == 0x1))
 #endif
 
 #ifndef IN6_IS_ADDR_MC_LINKLOCAL
 #define IN6_IS_ADDR_MC_LINKLOCAL(a) \
-        (IN6_IS_ADDR_MULTICAST(a) && ((((u_int8_t*)(a))[1] & 0xf) == 0x2))
+        (IN6_IS_ADDR_MULTICAST(a) && ((((const u_int8_t*)(a))[1] & 0xf) == 0x2))
 #endif
 
 #ifndef IN6_IS_ADDR_MC_SITELOCAL
 #define IN6_IS_ADDR_MC_SITELOCAL(a) \
-        (IN6_IS_ADDR_MULTICAST(a) && ((((u_int8_t*)(a))[1] & 0xf) == 0x5))
+        (IN6_IS_ADDR_MULTICAST(a) && ((((const u_int8_t*)(a))[1] & 0xf) == 0x5))
 #endif
 
 #ifndef IN6_IS_ADDR_MC_ORGLOCAL
 #define IN6_IS_ADDR_MC_ORGLOCAL(a)  \
-        (IN6_IS_ADDR_MULTICAST(a) && ((((u_int8_t*)(a))[1] & 0xf) == 0x8))
+        (IN6_IS_ADDR_MULTICAST(a) && ((((const u_int8_t*)(a))[1] & 0xf) == 0x8))
 #endif
 
 #ifndef IN6_IS_ADDR_MC_GLOBAL
 #define IN6_IS_ADDR_MC_GLOBAL(a)    \
-        (IN6_IS_ADDR_MULTICAST(a) && ((((u_int8_t*)(a))[1] & 0xf) == 0xe))
+        (IN6_IS_ADDR_MULTICAST(a) && ((((const u_int8_t*)(a))[1] & 0xf) == 0xe))
 #endif
 
 #endif /* __NETINET_IN_H */


### PR DESCRIPTION
In c-ares we get a bunch of warnings when compiling against WATT32 when using various macros in `netinet/in.h`.  This is because our sockaddr structures are tagged as `const` in a lot of locations, but the macros are casting to different types thus dropping the `const` qualifier.

This PR just sprinkles some `const` qualifiers on these macros which will silence the warnings in c-ares without introducing warnings if the structure passed in is not `const`.

Here are the warnings without the patch:
```
In file included from D:/a/c-ares/c-ares/watt-32/inc/sys/socket.h:64,
                 from src/lib/setup_once.h:94,
                 from src/lib/ares_setup.h:229,
                 from src/lib/ares__sortaddrinfo.c:39:
src/lib/ares__sortaddrinfo.c: In function 'get_scope':
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:416:36: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  416 | #define IN6_IS_ADDR_MULTICAST(a) (((u_int8_t*) (a))[0] == 0xff)
      |                                    ^
src/lib/ares__sortaddrinfo.c:96:9: note: in expansion of macro 'IN6_IS_ADDR_MULTICAST'
   96 |     if (IN6_IS_ADDR_MULTICAST(&addr6->sin6_addr)) {
      |         ^~~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:409:14: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  409 |            (((u_int32_t*)(a))[0] == 0   \
      |              ^
src/lib/ares__sortaddrinfo.c:98:16: note: in expansion of macro 'IN6_IS_ADDR_LOOPBACK'
   98 |     } else if (IN6_IS_ADDR_LOOPBACK(&addr6->sin6_addr) ||
      |                ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:410:14: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  410 |          && ((u_int32_t*)(a))[1] == 0   \
      |              ^
src/lib/ares__sortaddrinfo.c:98:16: note: in expansion of macro 'IN6_IS_ADDR_LOOPBACK'
   98 |     } else if (IN6_IS_ADDR_LOOPBACK(&addr6->sin6_addr) ||
      |                ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:411:14: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  411 |          && ((u_int32_t*)(a))[2] == 0   \
      |              ^
src/lib/ares__sortaddrinfo.c:98:16: note: in expansion of macro 'IN6_IS_ADDR_LOOPBACK'
   98 |     } else if (IN6_IS_ADDR_LOOPBACK(&addr6->sin6_addr) ||
      |                ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:412:14: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  412 |          && ((u_int32_t*)(a))[3] == htonl (1))
      |              ^
src/lib/ares__sortaddrinfo.c:98:16: note: in expansion of macro 'IN6_IS_ADDR_LOOPBACK'
   98 |     } else if (IN6_IS_ADDR_LOOPBACK(&addr6->sin6_addr) ||
      |                ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:420:12: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  420 |         ((((u_int32_t*)(a))[0] & htonl(0xffc00000)) == htonl(0xfe[80](https://github.com/c-ares/c-ares/actions/runs/9633327808/job/26567623510#step:9:81)0000))
      |            ^
src/lib/ares__sortaddrinfo.c:99:16: note: in expansion of macro 'IN6_IS_ADDR_LINKLOCAL'
   99 |                IN6_IS_ADDR_LINKLOCAL(&addr6->sin6_addr)) {
      |                ^~~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:424:12: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  424 |         ((((u_int32_t*)(a))[0] & htonl(0xffc00000)) == htonl(0xfec00000))
      |            ^
src/lib/ares__sortaddrinfo.c:105:16: note: in expansion of macro 'IN6_IS_ADDR_SITELOCAL'
  105 |     } else if (IN6_IS_ADDR_SITELOCAL(&addr6->sin6_addr)) {
      |                ^~~~~~~~~~~~~~~~~~~~~
src/lib/ares__sortaddrinfo.c: In function 'get_label':
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:409:14: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  409 |            (((u_int32_t*)(a))[0] == 0   \
      |              ^
src/lib/ares__sortaddrinfo.c:142:9: note: in expansion of macro 'IN6_IS_ADDR_LOOPBACK'
  142 |     if (IN6_IS_ADDR_LOOPBACK(&addr6->sin6_addr)) {
      |         ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:410:14: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  410 |          && ((u_int32_t*)(a))[1] == 0   \
      |              ^
src/lib/ares__sortaddrinfo.c:142:9: note: in expansion of macro 'IN6_IS_ADDR_LOOPBACK'
  142 |     if (IN6_IS_ADDR_LOOPBACK(&addr6->sin6_addr)) {
      |         ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:411:14: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  411 |          && ((u_int32_t*)(a))[2] == 0   \
      |              ^
src/lib/ares__sortaddrinfo.c:142:9: note: in expansion of macro 'IN6_IS_ADDR_LOOPBACK'
  142 |     if (IN6_IS_ADDR_LOOPBACK(&addr6->sin6_addr)) {
      |         ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:412:14: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  412 |          && ((u_int32_t*)(a))[3] == htonl (1))
      |              ^
src/lib/ares__sortaddrinfo.c:142:9: note: in expansion of macro 'IN6_IS_ADDR_LOOPBACK'
  142 |     if (IN6_IS_ADDR_LOOPBACK(&addr6->sin6_addr)) {
      |         ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:429:15: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  429 |            ((((u_int32_t*)(a))[0] == 0) \
      |               ^
src/lib/ares__sortaddrinfo.c:144:16: note: in expansion of macro 'IN6_IS_ADDR_V4MAPPED'
  144 |     } else if (IN6_IS_ADDR_V4MAPPED(&addr6->sin6_addr)) {
      |                ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:430:15: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  430 |          && (((u_int32_t*)(a))[1] == 0) \
      |               ^
src/lib/ares__sortaddrinfo.c:144:16: note: in expansion of macro 'IN6_IS_ADDR_V4MAPPED'
  144 |     } else if (IN6_IS_ADDR_V4MAPPED(&addr6->sin6_addr)) {
      |                ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:431:15: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  431 |          && (((u_int32_t*)(a))[2] == htonl(0xffff)))
      |               ^
src/lib/ares__sortaddrinfo.c:144:16: note: in expansion of macro 'IN6_IS_ADDR_V4MAPPED'
  144 |     } else if (IN6_IS_ADDR_V4MAPPED(&addr6->sin6_addr)) {
      |                ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:436:15: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  436 |            ((((u_int32_t*)(a))[0] == 0) \
      |               ^
src/lib/ares__sortaddrinfo.c:152:16: note: in expansion of macro 'IN6_IS_ADDR_V4COMPAT'
  152 |     } else if (IN6_IS_ADDR_V4COMPAT(&addr6->sin6_addr)) {
      |                ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:437:15: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  437 |          && (((u_int32_t*)(a))[1] == 0) \
      |               ^
src/lib/ares__sortaddrinfo.c:152:16: note: in expansion of macro 'IN6_IS_ADDR_V4COMPAT'
  152 |     } else if (IN6_IS_ADDR_V4COMPAT(&addr6->sin6_addr)) {
      |                ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:438:15: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  438 |          && (((u_int32_t*)(a))[2] == 0) \
      |               ^
src/lib/ares__sortaddrinfo.c:152:16: note: in expansion of macro 'IN6_IS_ADDR_V4COMPAT'
  152 |     } else if (IN6_IS_ADDR_V4COMPAT(&addr6->sin6_addr)) {
      |                ^~~~~~~~~~~~~~~~~~~~
In file included from D:/a/c-ares/c-ares/watt-32/inc/tcp.h:47,
                 from ./include/ares.h:90,
                 from src/lib/ares__sortaddrinfo.c:54:
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:439:21: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  439 |          && (ntohl(((u_int32_t*)(a))[3]) > 1))
      |                     ^
D:/a/c-ares/c-ares/watt-32/inc/sys/swap.h:58:41: note: in definition of macro 'intel'
   58 |   #define intel(x)   __builtin_bswap32 (x)
      |                                         ^
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:439:14: note: in expansion of macro 'ntohl'
  439 |          && (ntohl(((u_int32_t*)(a))[3]) > 1))
      |              ^~~~~
src/lib/ares__sortaddrinfo.c:152:16: note: in expansion of macro 'IN6_IS_ADDR_V4COMPAT'
  152 |     } else if (IN6_IS_ADDR_V4COMPAT(&addr6->sin6_addr)) {
      |                ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:424:12: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  424 |         ((((u_int32_t*)(a))[0] & htonl(0xffc00000)) == htonl(0xfec00000))
      |            ^
src/lib/ares__sortaddrinfo.c:154:16: note: in expansion of macro 'IN6_IS_ADDR_SITELOCAL'
  154 |     } else if (IN6_IS_ADDR_SITELOCAL(&addr6->sin6_addr)) {
      |                ^~~~~~~~~~~~~~~~~~~~~
src/lib/ares__sortaddrinfo.c: In function 'get_precedence':
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:409:14: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  409 |            (((u_int32_t*)(a))[0] == 0   \
      |              ^
src/lib/ares__sortaddrinfo.c:1[82](https://github.com/c-ares/c-ares/actions/runs/9633327808/job/26567623510#step:9:83):9: note: in expansion of macro 'IN6_IS_ADDR_LOOPBACK'
  182 |     if (IN6_IS_ADDR_LOOPBACK(&addr6->sin6_addr)) {
      |         ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:410:14: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  410 |          && ((u_int32_t*)(a))[1] == 0   \
      |              ^
src/lib/ares__sortaddrinfo.c:182:9: note: in expansion of macro 'IN6_IS_ADDR_LOOPBACK'
  182 |     if (IN6_IS_ADDR_LOOPBACK(&addr6->sin6_addr)) {
      |         ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:411:14: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  411 |          && ((u_int32_t*)(a))[2] == 0   \
      |              ^
src/lib/ares__sortaddrinfo.c:182:9: note: in expansion of macro 'IN6_IS_ADDR_LOOPBACK'
  182 |     if (IN6_IS_ADDR_LOOPBACK(&addr6->sin6_addr)) {
      |         ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:412:14: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  412 |          && ((u_int32_t*)(a))[3] == htonl (1))
      |              ^
src/lib/ares__sortaddrinfo.c:182:9: note: in expansion of macro 'IN6_IS_ADDR_LOOPBACK'
  182 |     if (IN6_IS_ADDR_LOOPBACK(&addr6->sin6_addr)) {
      |         ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:429:15: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  429 |            ((((u_int32_t*)(a))[0] == 0) \
      |               ^
src/lib/ares__sortaddrinfo.c:1[84](https://github.com/c-ares/c-ares/actions/runs/9633327808/job/26567623510#step:9:85):16: note: in expansion of macro 'IN6_IS_ADDR_V4MAPPED'
  184 |     } else if (IN6_IS_ADDR_V4MAPPED(&addr6->sin6_addr)) {
      |                ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:430:15: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  430 |          && (((u_int32_t*)(a))[1] == 0) \
      |               ^
src/lib/ares__sortaddrinfo.c:184:16: note: in expansion of macro 'IN6_IS_ADDR_V4MAPPED'
  184 |     } else if (IN6_IS_ADDR_V4MAPPED(&addr6->sin6_addr)) {
      |                ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:431:15: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  431 |          && (((u_int32_t*)(a))[2] == htonl(0xffff)))
      |               ^
src/lib/ares__sortaddrinfo.c:184:16: note: in expansion of macro 'IN6_IS_ADDR_V4MAPPED'
  184 |     } else if (IN6_IS_ADDR_V4MAPPED(&addr6->sin6_addr)) {
      |                ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:436:15: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  436 |            ((((u_int32_t*)(a))[0] == 0) \
      |               ^
src/lib/ares__sortaddrinfo.c:1[92](https://github.com/c-ares/c-ares/actions/runs/9633327808/job/26567623510#step:9:93):16: note: in expansion of macro 'IN6_IS_ADDR_V4COMPAT'
  192 |     } else if (IN6_IS_ADDR_V4COMPAT(&addr6->sin6_addr) ||
      |                ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:437:15: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  437 |          && (((u_int32_t*)(a))[1] == 0) \
      |               ^
src/lib/ares__sortaddrinfo.c:192:16: note: in expansion of macro 'IN6_IS_ADDR_V4COMPAT'
  192 |     } else if (IN6_IS_ADDR_V4COMPAT(&addr6->sin6_addr) ||
      |                ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:438:15: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  438 |          && (((u_int32_t*)(a))[2] == 0) \
      |               ^
src/lib/ares__sortaddrinfo.c:192:16: note: in expansion of macro 'IN6_IS_ADDR_V4COMPAT'
  192 |     } else if (IN6_IS_ADDR_V4COMPAT(&addr6->sin6_addr) ||
      |                ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:439:21: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  439 |          && (ntohl(((u_int32_t*)(a))[3]) > 1))
      |                     ^
D:/a/c-ares/c-ares/watt-32/inc/sys/swap.h:58:41: note: in definition of macro 'intel'
   58 |   #define intel(x)   __builtin_bswap32 (x)
      |                                         ^
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:439:14: note: in expansion of macro 'ntohl'
  439 |          && (ntohl(((u_int32_t*)(a))[3]) > 1))
      |              ^~~~~
src/lib/ares__sortaddrinfo.c:192:16: note: in expansion of macro 'IN6_IS_ADDR_V4COMPAT'
  192 |     } else if (IN6_IS_ADDR_V4COMPAT(&addr6->sin6_addr) ||
      |                ^~~~~~~~~~~~~~~~~~~~
D:/a/c-ares/c-ares/watt-32/inc/netinet/in.h:424:12: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
  424 |         ((((u_int32_t*)(a))[0] & htonl(0xffc00000)) == htonl(0xfec00000))
      |            ^
src/lib/ares__sortaddrinfo.c:1[93](https://github.com/c-ares/c-ares/actions/runs/9633327808/job/26567623510#step:9:94):16: note: in expansion of macro 'IN6_IS_ADDR_SITELOCAL'
  193 |                IN6_IS_ADDR_SITELOCAL(&addr6->sin6_addr) ||
      |                ^~~~~~~~~~~~~~~~~~~~~
```